### PR TITLE
Ensure additional libraries are added to the APP-INF/lib or WEB-INF/lib

### DIFF
--- a/lib/java_buildpack/container/weblogic.rb
+++ b/lib/java_buildpack/container/weblogic.rb
@@ -93,6 +93,7 @@ module JavaBuildpack
       def compile
         download_and_install_wls
         configure
+        @droplet.additional_libraries.link_to app_web_inf_lib
 
         # Don't modify context root for wars within Ear as there can be multiple wars.
         # Modify the context root to '/' in case of war
@@ -303,6 +304,10 @@ module JavaBuildpack
       # The root directory of the application being deployed
       def deployed_app_root
         @domain_apps_dir + APP_NAME
+      end
+
+      def app_web_inf_lib
+        web_inf? ? @droplet.root + 'WEB-INF/lib' : @droplet.root + 'APP-INF/lib'
       end
 
       def web_inf?


### PR DESCRIPTION
Buildpack frameworks such as Spring auto reconfiguration require dynamic JARs to be added
to the app server classpath or application lib folder to work; this fix is similar to Tomcat's approach of symlinking the JARs in the application lib folders.